### PR TITLE
fix(mcp): apply shared gqlgen extensions to MCP executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION   := $(shell git describe --tags || echo "v0.0.0")
 VER_CUT   := $(shell echo $(VERSION) | cut -c2-)
 
 # Dependency versions
-GOLANGCI_VERSION   = latest
+GOLANGCI_VERSION   = v2.12.1
 PROTOC_VERSION             = 33.4
 PROTOC_GEN_GO_VERSION      = $(shell go list -m -f '{{.Version}}' google.golang.org/protobuf)
 PROTOC_GEN_GO_GRPC_VERSION = v1.5.1
@@ -78,7 +78,7 @@ podman-push-multiarch:
 
 tools-golangci-lint: ## install golangci-lint
 	@mkdir -p $(PATHINSTBIN)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINARY=golangci-lint bash -s -- ${GOLANGCI_VERSION}
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_VERSION)/install.sh | sh -s -- -b $(PATHINSTBIN) $(GOLANGCI_VERSION)
 
 tools-protoc: ## install protoc
 	@mkdir -p $(PATHINSTBIN)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/DIMO-Network/clickhouse-infra v0.0.7
 	github.com/DIMO-Network/cloudevent v0.2.9
-	github.com/DIMO-Network/server-garage v0.1.1
+	github.com/DIMO-Network/server-garage v0.4.0
 	github.com/DIMO-Network/shared v1.1.7
 	github.com/DIMO-Network/token-exchange-api v0.4.0
 	github.com/auth0/go-jwt-middleware/v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/DIMO-Network/clickhouse-infra v0.0.7 h1:TAsjkFFKu3D5Xg6dwBcRBryjCVSlX
 github.com/DIMO-Network/clickhouse-infra v0.0.7/go.mod h1:XS80lhSJNWBWGgZ+m4j7++zFj1wAXfmtV2gJfhGlabQ=
 github.com/DIMO-Network/cloudevent v0.2.9 h1:8MxbZtNReMHbwPUGQc2+G5THf08dFxju+npKZFZygJc=
 github.com/DIMO-Network/cloudevent v0.2.9/go.mod h1:I/9NcpMozV5Fw194WimhbkAsJtKVZf5UKYJ9hgc8Cdg=
-github.com/DIMO-Network/server-garage v0.1.1 h1:EYmyy+Fgi2BNW0Bufn04BViDtb8BCWaN7C7BbEuoI5s=
-github.com/DIMO-Network/server-garage v0.1.1/go.mod h1:Z3A1KDUsXey+XhrPhmw/wyCidfrQvmEdWp7nShno7ZM=
+github.com/DIMO-Network/server-garage v0.4.0 h1:3ukXvtldIhLldn9AtbtQBooBjT2gicvB3WphrsjNQho=
+github.com/DIMO-Network/server-garage v0.4.0/go.mod h1:Z3A1KDUsXey+XhrPhmw/wyCidfrQvmEdWp7nShno7ZM=
 github.com/DIMO-Network/shared v1.1.7 h1:5Ex8bZ6BpOjcLj4u7n5Kih1Ho6b9BVJsKpKn4iU2EaM=
 github.com/DIMO-Network/shared v1.1.7/go.mod h1:lDHUKwwT2LW6Zvd42Nb33dXklRNTmfyOlbUNx2dQfGY=
 github.com/DIMO-Network/token-exchange-api v0.4.0 h1:EayDrw9VdyAfc6rbpdnDxFhlN3lMhbonUJoouKZu35g=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/executor"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
@@ -86,7 +87,13 @@ func New(settings config.Settings) (*App, error) {
 
 	serverHandler := authChain(gqlSrv)
 
-	mcpHandler, err := mcpserver.New(mcpserver.NewGQLGenExecutor(es), "DIMO Fetch", "0.1.0", "fetch",
+	// The MCP executor gets the same extension set as the HTTP GraphQL server
+	// so tool calls are complexity-limited, traced, and error-shaped identically.
+	mcpExec := mcpserver.NewGQLGenExecutor(es, func(e *executor.Executor) {
+		configureGQLExtensions(e)
+	})
+
+	mcpHandler, err := mcpserver.New(mcpExec, "DIMO Fetch", "0.1.0", "fetch",
 		mcpserver.WithTools(graph.MCPTools),
 		mcpserver.WithCondensedSchema(graph.CondensedSchema),
 	)
@@ -124,11 +131,26 @@ func newGraphQLHandler(es graphql.ExecutableSchema) *handler.Server {
 	srv.AddTransport(transport.Options{})
 	srv.AddTransport(transport.GET{})
 	srv.AddTransport(transport.POST{})
+	configureGQLExtensions(srv)
+	return srv
+}
+
+// gqlExtensionTarget is satisfied by both *handler.Server and
+// *executor.Executor, letting the HTTP GraphQL server and the MCP executor
+// share one extension configuration.
+type gqlExtensionTarget interface {
+	Use(graphql.HandlerExtension)
+	SetErrorPresenter(graphql.ErrorPresenterFunc)
+}
+
+// configureGQLExtensions applies the extension set shared by the HTTP GraphQL
+// server and the MCP executor: introspection, complexity limit, metrics, and
+// error shaping.
+func configureGQLExtensions(srv gqlExtensionTarget) {
 	srv.Use(extension.Introspection{})
 	srv.Use(extension.FixedComplexityLimit(100))
 	srv.Use(gqlmetrics.Tracer{})
 	srv.SetErrorPresenter(errorhandler.ErrorPresenter)
-	return srv
 }
 
 // CreateGRPCServer creates a new gRPC server with the given logger and settings.


### PR DESCRIPTION
## Problem

Same gap fixed in DIMO-Network/telemetry-api#300: the MCP handler used a bare gqlgen executor, so everything registered on the HTTP GraphQL server via `srv.Use` was bypassed on MCP tool calls — `FixedComplexityLimit(100)`, introspection, the metrics tracer, and the error presenter.

## Fix

- `configureGQLExtensions` holds the single shared extension list, applied to both `*handler.Server` and the MCP `*executor.Executor` via server-garage v0.4.0's `ExecutorOption` hook.
- Bumps server-garage v0.1.1 → v0.4.0 ([release notes](https://github.com/DIMO-Network/server-garage/releases/tag/v0.4.0)).

## Testing

Full `go test ./...` + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)